### PR TITLE
Fix target logic being executed on sample weights

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perpetual"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 authors = ["Mutlu Simsek <msimsek@perpetual-ml.com>"]
 homepage = "https://perpetual-ml.com"

--- a/python-package/Cargo.toml
+++ b/python-package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-perpetual"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 authors = ["Mutlu Simsek <msimsek@perpetual-ml.com>"]
 homepage = "https://perpetual-ml.com"
@@ -19,7 +19,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 pyo3 = { version = "0.23.5", features = ["extension-module"] }
-perpetual_rs = {package="perpetual", version = "0.9.1", path = "../" }
+perpetual_rs = {package="perpetual", version = "0.9.2", path = "../" }
 numpy = "0.23.0"
 ndarray = "0.16.1"
 serde_plain = { version = "1.0.2" }

--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "perpetual"
-version = "0.9.1"
+version = "0.9.2"
 description = "A self-generalizing gradient boosting machine that doesn't need hyperparameter optimization"
 keywords = [
   "rust",

--- a/python-package/python/perpetual/booster.py
+++ b/python-package/python/perpetual/booster.py
@@ -227,7 +227,7 @@ class PerpetualBooster:
         self.cat_mapping = cat_mapping
         self.feature_names_in_ = features_
 
-        y_, classes_ = convert_input_array(y, self.objective, is_target = True)
+        y_, classes_ = convert_input_array(y, self.objective, is_target=True)
         self.classes_ = np.array(classes_).tolist()
 
         if sample_weight is None:

--- a/python-package/python/perpetual/booster.py
+++ b/python-package/python/perpetual/booster.py
@@ -227,7 +227,7 @@ class PerpetualBooster:
         self.cat_mapping = cat_mapping
         self.feature_names_in_ = features_
 
-        y_, classes_ = convert_input_array(y, self.objective)
+        y_, classes_ = convert_input_array(y, self.objective, is_target = True)
         self.classes_ = np.array(classes_).tolist()
 
         if sample_weight is None:

--- a/python-package/python/perpetual/utils.py
+++ b/python-package/python/perpetual/utils.py
@@ -32,7 +32,7 @@ def type_series(y):
         return ""
 
 
-def convert_input_array(x, objective) -> np.ndarray:
+def convert_input_array(x, objective, is_target = False) -> np.ndarray:
     classes_ = []
 
     if type(x).__module__.split(".")[0] == "numpy":
@@ -49,7 +49,7 @@ def convert_input_array(x, objective) -> np.ndarray:
     else:
         x_ = x.to_numpy()
 
-    if objective == "LogLoss" and len(x_.shape) == 1:
+    if objective == "LogLoss" and len(x_.shape) == 1 and is_target:
         classes_ = np.unique(x_)
         x_index = np.array([np.where(classes_ == i) for i in x_])
         if len(classes_) > 2:

--- a/python-package/python/perpetual/utils.py
+++ b/python-package/python/perpetual/utils.py
@@ -32,7 +32,7 @@ def type_series(y):
         return ""
 
 
-def convert_input_array(x, objective, is_target = False) -> np.ndarray:
+def convert_input_array(x, objective, is_target=False) -> np.ndarray:
     classes_ = []
 
     if type(x).__module__.split(".")[0] == "numpy":

--- a/python-package/python/perpetual/utils.py
+++ b/python-package/python/perpetual/utils.py
@@ -49,7 +49,7 @@ def convert_input_array(x, objective, is_target = False) -> np.ndarray:
     else:
         x_ = x.to_numpy()
 
-    if objective == "LogLoss" and len(x_.shape) == 1 and is_target:
+    if is_target and objective == "LogLoss" and len(x_.shape) == 1:
         classes_ = np.unique(x_)
         x_index = np.array([np.where(classes_ == i) for i in x_])
         if len(classes_) > 2:

--- a/python-package/uv.lock
+++ b/python-package/uv.lock
@@ -1228,7 +1228,7 @@ wheels = [
 
 [[package]]
 name = "perpetual"
-version = "0.9.1"
+version = "0.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },

--- a/scripts/make_resources.py
+++ b/scripts/make_resources.py
@@ -7,7 +7,7 @@ from perpetual.utils import convert_input_frame, transform_input_frame
 if __name__ == "__main__":
     df = sns.load_dataset("titanic")
     df.to_csv("resources/titanic.csv", index=False)
-    
+
     X = df.select_dtypes("number").drop(columns=["survived"]).astype(float)
     y = df["survived"].astype(float)
 
@@ -66,37 +66,59 @@ if __name__ == "__main__":
     data_train.to_csv("resources/cover_types_train.csv", index=False)
     data_test.to_csv("resources/cover_types_test.csv", index=False)
 
-    
-
-  
-
     X = df.drop(columns=["survived"])
     y = df["survived"]
 
     X["sex"] = pd.get_dummies(X["sex"], drop_first=True, dtype=float).to_numpy()
-    X["adult_male"] = pd.get_dummies(X["adult_male"], drop_first=True, dtype=float).to_numpy()
+    X["adult_male"] = pd.get_dummies(
+        X["adult_male"], drop_first=True, dtype=float
+    ).to_numpy()
     X.drop(columns=["alive"], inplace=True)
     X["alone"] = pd.get_dummies(X["alone"], drop_first=True, dtype=float).to_numpy()
-    cols = ['pclass', 'sibsp', 'parch', 'embarked', 'class', 'who', 'deck', 'embark_town']
-    X[cols] = X[cols].astype('category')
+    cols = [
+        "pclass",
+        "sibsp",
+        "parch",
+        "embarked",
+        "class",
+        "who",
+        "deck",
+        "embark_town",
+    ]
+    X[cols] = X[cols].astype("category")
 
-    data_train, data_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+    data_train, data_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42
+    )
 
-    features_, titanic_train_flat, rows, cols, categorical_features_, cat_mapping = convert_input_frame(data_train, "auto", 1000)
-    features_, titanic_test_flat, rows, cols = transform_input_frame(data_test, cat_mapping)
+    features_, titanic_train_flat, rows, cols, categorical_features_, cat_mapping = (
+        convert_input_frame(data_train, "auto", 1000)
+    )
+    features_, titanic_test_flat, rows, cols = transform_input_frame(
+        data_test, cat_mapping
+    )
 
     data_test.to_csv("resources/titanic_test_df.csv", index=False)
 
-    pd.Series(titanic_train_flat).to_csv("resources/titanic_train_flat.csv", index=False, header=False)
-    pd.Series(titanic_test_flat).to_csv("resources/titanic_test_flat.csv", index=False, header=False)
-    pd.Series(y_train).to_csv("resources/titanic_train_y.csv", index=False, header=False)
+    pd.Series(titanic_train_flat).to_csv(
+        "resources/titanic_train_flat.csv", index=False, header=False
+    )
+    pd.Series(titanic_test_flat).to_csv(
+        "resources/titanic_test_flat.csv", index=False, header=False
+    )
+    pd.Series(y_train).to_csv(
+        "resources/titanic_train_y.csv", index=False, header=False
+    )
     pd.Series(y_test).to_csv("resources/titanic_test_y.csv", index=False, header=False)
-
 
     # https://www.openml.org/search?type=data&id=546&sort=runs&status=active
     df = fetch_openml(data_id=546)
     X = df.data
     y = df.target
-    features_, sensory_flat, rows, cols, categorical_features_, cat_mapping = convert_input_frame(X, "auto", 1000)
-    pd.Series(sensory_flat).to_csv("resources/sensory_flat.csv", index=False, header=False)
+    features_, sensory_flat, rows, cols, categorical_features_, cat_mapping = (
+        convert_input_frame(X, "auto", 1000)
+    )
+    pd.Series(sensory_flat).to_csv(
+        "resources/sensory_flat.csv", index=False, header=False
+    )
     pd.Series(y).to_csv("resources/sensory_y.csv", index=False, header=False)


### PR DESCRIPTION
Hello,

Thanks for great package. For context, I was just trying to fit a model with sample weights passed to it and it was always resulting in 0 trees trained in a couple of seconds. Other than that noticed much higher memory usage with sample_weight argument passed to fit. Without sample weights model was being trained just fine. 

I noticed the `convert_input_array` function executes a logic meant for targets on sample weights as well, corrupting sample weights, leading to a large vector (from 5000 to 2M+ datapoints). I added an extra flag indicating we're dealing with a target. This effectively fixed the issue.