### PR TITLE
Ranking objectives support + ListNet loss function + NDCG@k ranking metric

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perpetual"
-version = "0.9.4-dev.1"
+version = "0.9.4-dev.2"
 edition = "2021"
 authors = ["Mutlu Simsek <msimsek@perpetual-ml.com>"]
 homepage = "https://perpetual-ml.com"

--- a/examples/cal_housing.rs
+++ b/examples/cal_housing.rs
@@ -124,7 +124,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .set_budget(*budget);
 
     let now = SystemTime::now();
-    model.fit(&matrix_train, &y_train, None)?;
+    model.fit(&matrix_train, &y_train, None, None)?;
     println!("now.elapsed: {:?}", now.elapsed().unwrap().as_secs_f32());
 
     let trees = model.get_prediction_trees();

--- a/examples/cover_types.rs
+++ b/examples/cover_types.rs
@@ -150,7 +150,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             .map(|y| if (*y as i32) == i { 1.0 } else { 0.0 })
             .collect();
 
-        model.fit(&matrix_train, &y_tr, None)?;
+        model.fit(&matrix_train, &y_tr, None, None)?;
         println!("Completed fitting model number: {}", i);
 
         let trees = model.get_prediction_trees();

--- a/examples/custom_loss_function.rs
+++ b/examples/custom_loss_function.rs
@@ -27,7 +27,7 @@ use perpetual::{Matrix, UnivariateBooster};
 struct CustomSquaredLoss;
 impl perpetual::objective_functions::ObjectiveFunction for CustomSquaredLoss {
     #[inline]
-    fn loss(&self, y: &[f64], yhat: &[f64], sample_weight: Option<&[f64]>) -> Vec<f32> {
+    fn loss(&self, y: &[f64], yhat: &[f64], sample_weight: Option<&[f64]>, _group: Option<&[u64]>) -> Vec<f32> {
         match sample_weight {
             Some(sample_weight) => y
                 .iter()
@@ -50,7 +50,13 @@ impl perpetual::objective_functions::ObjectiveFunction for CustomSquaredLoss {
     }
 
     #[inline]
-    fn gradient(&self, y: &[f64], yhat: &[f64], sample_weight: Option<&[f64]>) -> (Vec<f32>, Option<Vec<f32>>) {
+    fn gradient(
+        &self,
+        y: &[f64],
+        yhat: &[f64],
+        sample_weight: Option<&[f64]>,
+        _group: Option<&[u64]>,
+    ) -> (Vec<f32>, Option<Vec<f32>>) {
         match sample_weight {
             Some(sample_weight) => {
                 let (g, h) = y
@@ -68,7 +74,7 @@ impl perpetual::objective_functions::ObjectiveFunction for CustomSquaredLoss {
         }
     }
 
-    fn initial_value(&self, y: &[f64], sample_weight: Option<&[f64]>) -> f64 {
+    fn initial_value(&self, y: &[f64], sample_weight: Option<&[f64]>, _group: Option<&[u64]>) -> f64 {
         if let Some(w) = sample_weight {
             let sum_w: f64 = w.iter().sum();
             y.iter().zip(w).map(|(yi, wi)| yi * wi).sum::<f64>() / sum_w
@@ -148,7 +154,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     //-------------------//
     // 3. Fit and report //
     //-------------------//
-    booster.fit(&matrix, &y, None)?;
+    booster.fit(&matrix, &y, None, None)?;
 
     let n_trees = booster.get_prediction_trees().len();
     println!("Model trained with {n_trees} trees (budget = {})", booster.cfg.budget);

--- a/examples/titanic.rs
+++ b/examples/titanic.rs
@@ -53,7 +53,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut model = UnivariateBooster::default()
         .set_objective(Objective::LogLoss)
         .set_budget(*budget);
-    model.fit(&matrix, &y, None)?;
+    model.fit(&matrix, &y, None, None)?;
 
     println!("Model prediction: {:?} ...", &model.predict(&matrix, true)[0..10]);
 

--- a/python-package/Cargo.toml
+++ b/python-package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-perpetual"
-version = "0.9.3"
+version = "0.9.4-dev.2"
 edition = "2021"
 authors = ["Mutlu Simsek <msimsek@perpetual-ml.com>"]
 homepage = "https://perpetual-ml.com"
@@ -19,7 +19,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 pyo3 = { version = "0.24.1", features = ["extension-module"] }
-perpetual_rs = {package="perpetual", version = "0.9.3", path = "../" }
+perpetual_rs = {package="perpetual", version = "0.9.4-dev.2", path = "../" }
 numpy = "0.24.0"
 ndarray = "0.16.1"
 serde_plain = { version = "1.0.2" }

--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "perpetual"
-version = "0.9.3"
+version = "0.9.4-dev.2"
 description = "A self-generalizing gradient boosting machine that doesn't need hyperparameter optimization"
 keywords = [
   "rust",

--- a/python-package/python/perpetual/booster.py
+++ b/python-package/python/perpetual/booster.py
@@ -252,7 +252,7 @@ class PerpetualBooster:
         if group is None:
             group_ = None
         else:
-            group_, _ = convert_input_array(group, self.objective, is_int = True)
+            group_, _ = convert_input_array(group, self.objective, is_int=True)
 
         # Convert the monotone constraints into the form needed
         # by the rust code.

--- a/python-package/python/perpetual/booster.py
+++ b/python-package/python/perpetual/booster.py
@@ -71,6 +71,7 @@ class PerpetualBooster:
                 "QuantileLoss" to use quantile error (regression),
                 "HuberLoss" to use huber error (regression),
                 "AdaptiveHuberLoss" to use adaptive huber error (regression).
+                "ListNetLoss" to use ListNet loss (ranking).
                 Defaults to "LogLoss".
             budget (float, optional): a positive number for fitting budget. Increasing this number will more
                 likely result in more boosting rounds and more increased predictive power.

--- a/python-package/python/perpetual/booster.py
+++ b/python-package/python/perpetual/booster.py
@@ -248,6 +248,11 @@ class PerpetualBooster:
         else:
             sample_weight_, _ = convert_input_array(sample_weight, self.objective)
 
+        if group is None:
+            group_ = None
+        else:
+            group_, _ = convert_input_array(group, self.objective, is_int = True)
+
         # Convert the monotone constraints into the form needed
         # by the rust code.
         crate_mc = self._standardize_monotonicity_map(X)
@@ -319,7 +324,7 @@ class PerpetualBooster:
             cols=cols,
             y=y_,
             sample_weight=sample_weight_,  # type: ignore
-            group=group,
+            group=group_,
         )
 
         return self
@@ -348,13 +353,18 @@ class PerpetualBooster:
         else:
             sample_weight_, _ = convert_input_array(sample_weight, self.objective)
 
+        if group is None:
+            group_ = None
+        else:
+            group_, _ = convert_input_array(group, self.objective, is_int=True)
+
         self.booster.prune(
             flat_data=flat_data,
             rows=rows,
             cols=cols,
             y=y_,
             sample_weight=sample_weight_,  # type: ignore
-            group=group,
+            group=group_,
         )
 
         return self

--- a/python-package/python/perpetual/booster.py
+++ b/python-package/python/perpetual/booster.py
@@ -1,16 +1,18 @@
-import json
 import inspect
+import json
 import warnings
-from typing_extensions import Self
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union, cast
 
 import numpy as np
-
-from perpetual.perpetual import PerpetualBooster as CratePerpetualBooster  # type: ignore
-from perpetual.perpetual import MultiOutputBooster as CrateMultiOutputBooster  # type: ignore
+from perpetual.data import Node
+from perpetual.perpetual import (
+    MultiOutputBooster as CrateMultiOutputBooster,  # type: ignore
+)
+from perpetual.perpetual import (
+    PerpetualBooster as CratePerpetualBooster,  # type: ignore
+)
 from perpetual.serialize import BaseSerializer, ObjectSerializer
 from perpetual.types import BoosterType, MultiOutputBoosterType
-from perpetual.data import Node
 from perpetual.utils import (
     CONTRIBUTION_METHODS,
     convert_input_array,
@@ -18,6 +20,7 @@ from perpetual.utils import (
     transform_input_frame,
     type_df,
 )
+from typing_extensions import Self
 
 
 class PerpetualBooster:
@@ -210,7 +213,7 @@ class PerpetualBooster:
         )
         self.booster = cast(BoosterType, booster)
 
-    def fit(self, X, y, sample_weight=None) -> Self:
+    def fit(self, X, y, sample_weight=None, group=None) -> Self:
         """Fit the gradient booster on a provided dataset.
 
         Args:
@@ -220,11 +223,19 @@ class PerpetualBooster:
             sample_weight (Union[ArrayLike, None], optional): Instance weights to use when
                 training the model. If None is passed, a weight of 1 will be used for every record.
                 Defaults to None.
+            group (Union[ArrayLike, None], optional): Group lengths to use for a ranking objective.
+                If None is passes, all items are assumed to be in the same group.
+                Defaults to None.
         """
 
-        features_, flat_data, rows, cols, categorical_features_, cat_mapping = (
-            convert_input_frame(X, self.categorical_features, self.max_cat)
-        )
+        (
+            features_,
+            flat_data,
+            rows,
+            cols,
+            categorical_features_,
+            cat_mapping,
+        ) = convert_input_frame(X, self.categorical_features, self.max_cat)
         self.n_features_ = cols
         self.cat_mapping = cat_mapping
         self.feature_names_in_ = features_
@@ -308,11 +319,12 @@ class PerpetualBooster:
             cols=cols,
             y=y_,
             sample_weight=sample_weight_,  # type: ignore
+            group=group,
         )
 
         return self
 
-    def prune(self, X, y, sample_weight=None) -> Self:
+    def prune(self, X, y, sample_weight=None, group=None) -> Self:
         """Prune the gradient booster on a provided dataset.
 
         Args:
@@ -321,6 +333,9 @@ class PerpetualBooster:
                 or a 1 or 2 dimensional Numpy array.
             sample_weight (Union[ArrayLike, None], optional): Instance weights to use when
                 training the model. If None is passed, a weight of 1 will be used for every record.
+                Defaults to None.
+            group (Union[ArrayLike, None], optional): Group lengths to use for a ranking objective.
+                If None is passes, all items are assumed to be in the same group.
                 Defaults to None.
         """
 
@@ -339,12 +354,13 @@ class PerpetualBooster:
             cols=cols,
             y=y_,
             sample_weight=sample_weight_,  # type: ignore
+            group=group,
         )
 
         return self
 
     def calibrate(
-        self, X_train, y_train, X_cal, y_cal, alpha, sample_weight=None
+        self, X_train, y_train, X_cal, y_cal, alpha, sample_weight=None, group=None
     ) -> Self:
         """Calibrate the gradient booster on a provided dataset.
 
@@ -360,6 +376,9 @@ class PerpetualBooster:
                 alpha is the complement of the target coverage level.
             sample_weight (Union[ArrayLike, None], optional): Instance weights to use when
                 training the model. If None is passed, a weight of 1 will be used for every record.
+                Defaults to None.
+            group (Union[ArrayLike, None], optional): Group lengths to use for a ranking objective.
+                If None is passes, all items are assumed to be in the same group.
                 Defaults to None.
         """
 
@@ -391,6 +410,7 @@ class PerpetualBooster:
             y_cal=y_cal_,
             alpha=np.array(alpha),
             sample_weight=sample_weight_,  # type: ignore
+            group=group,
         )
 
         return self

--- a/python-package/python/perpetual/utils.py
+++ b/python-package/python/perpetual/utils.py
@@ -1,7 +1,7 @@
 import logging
-import numpy as np
 from typing import Dict, Iterable, List, Optional, Tuple
 
+import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +32,7 @@ def type_series(y):
         return ""
 
 
-def convert_input_array(x, objective, is_target=False) -> np.ndarray:
+def convert_input_array(x, objective, is_target=False, is_int=False) -> np.ndarray:
     classes_ = []
 
     if type(x).__module__.split(".")[0] == "numpy":
@@ -55,7 +55,10 @@ def convert_input_array(x, objective, is_target=False) -> np.ndarray:
         if len(classes_) > 2:
             x_ = np.squeeze(np.eye(len(classes_))[x_index])
 
-    if not np.issubdtype(x_.dtype, "float64"):
+    if is_int and not np.issubdtype(x_.dtype, "uint64"):
+        x_ = x_.astype(dtype="uint64", copy=False)
+
+    if not is_int and not np.issubdtype(x_.dtype, "float64"):
         x_ = x_.astype(dtype="float64", copy=False)
 
     if len(x_.shape) == 2:

--- a/scripts/make_resources.py
+++ b/scripts/make_resources.py
@@ -100,3 +100,13 @@ if __name__ == "__main__":
     features_, sensory_flat, rows, cols, categorical_features_, cat_mapping = convert_input_frame(X, "auto", 1000)
     pd.Series(sensory_flat).to_csv("resources/sensory_flat.csv", index=False, header=False)
     pd.Series(y).to_csv("resources/sensory_y.csv", index=False, header=False)
+
+    # https://www.openml.org/search?type=data&id=43493&sort=runs&status=active
+    df = fetch_openml(data_id=43493)
+    cols_to_drop = ["title", "authors", "votes"]
+    data = df.data.drop(columns=cols_to_drop)
+
+    data["category"] = data["category"].astype("category")
+    data["published"] = data["published"].astype("category")
+
+    data.to_csv("resources/goodreads.csv", index=False, header=True)

--- a/src/booster/multivariate_booster.rs
+++ b/src/booster/multivariate_booster.rs
@@ -148,9 +148,10 @@ impl MultivariateBooster {
         data: &Matrix<f64>,
         y: &Matrix<f64>,
         sample_weight: Option<&[f64]>,
+        group: Option<&[u64]>,
     ) -> Result<(), PerpetualError> {
         for i in 0..self.n_boosters {
-            let _ = self.boosters[i].fit(data, y.get_col(i), sample_weight);
+            let _ = self.boosters[i].fit(data, y.get_col(i), sample_weight, group);
         }
         Ok(())
     }
@@ -160,9 +161,10 @@ impl MultivariateBooster {
         data: &Matrix<f64>,
         y: &Matrix<f64>,
         sample_weight: Option<&[f64]>,
+        group: Option<&[u64]>,
     ) -> Result<(), PerpetualError> {
         for i in 0..self.n_boosters {
-            let _ = self.boosters[i].prune(data, y.get_col(i), sample_weight);
+            let _ = self.boosters[i].prune(data, y.get_col(i), sample_weight, group);
         }
         Ok(())
     }
@@ -530,7 +532,7 @@ mod multivariate_booster_test {
         println!("The number of boosters: {:?}", booster.get_boosters().len());
         assert!(booster.get_boosters().len() == n_classes);
 
-        booster.fit(&data, &y, None).unwrap();
+        booster.fit(&data, &y, None, None).unwrap();
 
         let probas = booster.predict_proba(&data, true);
 

--- a/src/booster/univariate_booster.rs
+++ b/src/booster/univariate_booster.rs
@@ -1251,12 +1251,20 @@ mod univariate_booster_test {
 
         let features = mdf.drop_many(&cols_to_drop);
 
+        let max_rank = mdf
+            .column("rank")?
+            .i64()?
+            .into_iter()
+            .map(|v| v.unwrap())
+            .max()
+            .unwrap();
+
         let y: Vec<f64> = mdf
             .column("rank")?
             .i64()?
             .into_iter()
             .map(|v| v.unwrap())
-            .map(|v| v as f64)
+            .map(|v| (max_rank - v) as f64) // Relevance
             .collect();
 
         let numeric_columns: Vec<Vec<f64>> = features
@@ -1310,7 +1318,7 @@ mod univariate_booster_test {
             &GainScheme::Burges,
         );
 
-        // TODO: set seed
+        // TODO: set seed?
         let mut rng = rand::rng();
         let random_guesses: Vec<f64> = (0..y.len())
             .map(|_| rng.random::<f64>()) // generates f64 in [0, 1)
@@ -1323,9 +1331,6 @@ mod univariate_booster_test {
             None,
             &GainScheme::Burges,
         );
-
-        println!("Final NDCG: {}", final_ndcg);
-        println!("Random NDCG: {}", random_ndcg);
 
         assert!(final_ndcg > random_ndcg);
 

--- a/src/booster/univariate_booster.rs
+++ b/src/booster/univariate_booster.rs
@@ -1225,7 +1225,6 @@ mod univariate_booster_test {
 
         println!("{:?}", groups.len());
 
-        // Count items per group
         let mut group_counts: HashMap<u64, u64> = HashMap::new();
         for group_id in &groups {
             *group_counts.entry(*group_id).or_default() += 1;
@@ -1240,8 +1239,6 @@ mod univariate_booster_test {
         let all_feature_names = [
             "avg_rating".to_string(),
             "pages".to_string(),
-            // "publisher".to_string(),
-            // "published".to_string(),
             "5stars".to_string(),
             "4stars".to_string(),
             "3stars".to_string(),
@@ -1253,17 +1250,9 @@ mod univariate_booster_test {
 
         let mdf = data.clone().select(all_feature_names.clone())?;
 
-        println!("{:?}", mdf.head(Some(5)));
-
         let cols_to_drop = ["rank".to_string()];
 
-        println!("{:?}", mdf.head(Some(5)));
-
         let features = mdf.drop_many(&cols_to_drop);
-
-        println!("{:?}", features.head(Some(5)));
-
-        println!("Shape of features: {:?}, {:?}", features.height(), features.width());
 
         let y: Vec<f64> = mdf
             .column("rank")?
@@ -1272,8 +1261,6 @@ mod univariate_booster_test {
             .map(|v| v.unwrap())
             .map(|v| v as f64)
             .collect();
-
-        println!("Shape of y: {}", y.len());
 
         let numeric_columns: Vec<Vec<f64>> = features
             .get_columns()
@@ -1298,14 +1285,7 @@ mod univariate_booster_test {
             .flat_map(|row_idx| numeric_columns.iter().map(move |col| col[row_idx]))
             .collect();
 
-        println!("Number of features: {:?}", flat_features.len());
-        println!("Number of y: {:?}", y.len());
-        println!("Number of groups: {:?}", group_counts_vec.len());
-        println!("Sum of groups: {:?}", group_counts_vec.iter().sum::<u64>());
-
         let num_cols = all_feature_names.len() - 1;
-
-        println!("Number of columns: {:?}", num_cols);
 
         let matrix = Matrix::new(&flat_features, y.len(), num_cols);
 

--- a/src/conformal/cqr.rs
+++ b/src/conformal/cqr.rs
@@ -12,6 +12,7 @@ impl UnivariateBooster {
         data: &Matrix<f64>,
         y: &[f64],
         sample_weight: Option<&[f64]>,
+        group: Option<&[u64]>,
         data_cal: CalData,
     ) -> Result<(), PerpetualError> {
         let (x_cal, y_cal, alpha) = data_cal;
@@ -21,14 +22,14 @@ impl UnivariateBooster {
             let mut model_lower = UnivariateBooster::default().set_objective(Objective::QuantileLoss {
                 quantile: lower_quantile,
             });
-            model_lower.fit(&data, &y, sample_weight)?;
+            model_lower.fit(&data, &y, sample_weight, group)?;
 
             let upper_quantile = Some(1.0 - alpha_ / 2.0);
             let mut model_upper = UnivariateBooster::default().set_objective(Objective::QuantileLoss {
                 quantile: upper_quantile,
             });
 
-            model_upper.fit(&data, &y, sample_weight)?;
+            model_upper.fit(&data, &y, sample_weight, group)?;
 
             let y_cal_pred_lower = model_lower.predict(&x_cal, true);
             let y_cal_pred_upper = model_upper.predict(&x_cal, true);
@@ -168,12 +169,12 @@ mod tests {
             .set_max_bin(10)
             .set_budget(0.1);
 
-        model.fit(&matrix_train, &y_train, None)?;
+        model.fit(&matrix_train, &y_train, None, None)?;
 
         let alpha = vec![0.1];
         let data_cal = (matrix_test, y_test.as_slice(), alpha.as_slice());
 
-        model.calibrate(&matrix_train, &y_train, None, data_cal)?;
+        model.calibrate(&matrix_train, &y_train, None, None, data_cal)?;
 
         let matrix_test = Matrix::new(&data_test, y_test.len(), 8);
         let _intervals = model.predict_intervals(&matrix_test, true);

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -339,7 +339,7 @@ mod tests {
 
         let y_avg = y.iter().sum::<f64>() / y.len() as f64;
         let yhat = vec![y_avg; y.len()];
-        let (g, h) = objective_function.gradient(&y, &yhat, None);
+        let (g, h) = objective_function.gradient(&y, &yhat, None, None);
 
         let col = 0;
         let mut hist_feat_owned = FeatureHistogramOwned::empty_from_cuts(&b.cuts.get_col(col), false);
@@ -395,7 +395,7 @@ mod tests {
         let bdata = Matrix::new(&b.binned_data, data.rows, data.cols);
         let y: Vec<f64> = file.lines().map(|x| x.parse::<f64>().unwrap()).collect();
         let yhat = vec![0.5; y.len()];
-        let (g, h) = objective_function.gradient(&y, &yhat, None);
+        let (g, h) = objective_function.gradient(&y, &yhat, None, None);
 
         let col_index: Vec<usize> = (0..data.cols).collect();
         let mut hist_init_owned = NodeHistogramOwned::empty_from_cuts(&b.cuts, &col_index, true, false);
@@ -459,7 +459,7 @@ mod tests {
         let bdata = Matrix::new(&b.binned_data, data.rows, data.cols);
         let y: Vec<f64> = file.lines().map(|x| x.parse::<f64>().unwrap_or(f64::NAN)).collect();
         let yhat = vec![0.5; y.len()];
-        let (g, h) = objective_function.gradient(&y, &yhat, None);
+        let (g, h) = objective_function.gradient(&y, &yhat, None, None);
 
         let col_index: Vec<usize> = (0..data.cols).collect();
         let mut hist_init_owned = NodeHistogramOwned::empty_from_cuts(&b.cuts, &col_index, false, false);
@@ -517,7 +517,7 @@ mod tests {
         let bdata = Matrix::new(&b.binned_data, data.rows, data.cols);
         let y: Vec<f64> = file.lines().map(|x| x.parse::<f64>().unwrap_or(f64::NAN)).collect();
         let yhat = vec![0.5; y.len()];
-        let (g, h) = objective_function.gradient(&y, &yhat, None);
+        let (g, h) = objective_function.gradient(&y, &yhat, None, None);
 
         let col_index: Vec<usize> = (0..data.cols).collect();
 

--- a/src/metrics/classification/metrics.rs
+++ b/src/metrics/classification/metrics.rs
@@ -2,7 +2,7 @@ use crate::metrics::*;
 
 pub struct LogLossMetric {}
 impl EvaluationMetric for LogLossMetric {
-    fn calculate_metric(y: &[f64], yhat: &[f64], sample_weight: &[f64], _alpha: Option<f32>) -> f64 {
+    fn calculate_metric(y: &[f64], yhat: &[f64], sample_weight: &[f64], group: &[u64], _alpha: Option<f32>) -> f64 {
         log_loss(y, yhat, sample_weight)
     }
     fn maximize() -> bool {
@@ -12,7 +12,7 @@ impl EvaluationMetric for LogLossMetric {
 
 pub struct AUCMetric {}
 impl EvaluationMetric for AUCMetric {
-    fn calculate_metric(y: &[f64], yhat: &[f64], sample_weight: &[f64], _alpha: Option<f32>) -> f64 {
+    fn calculate_metric(y: &[f64], yhat: &[f64], sample_weight: &[f64], group: &[u64], _alpha: Option<f32>) -> f64 {
         roc_auc_score(y, yhat, sample_weight)
     }
     fn maximize() -> bool {

--- a/src/metrics/classification/metrics.rs
+++ b/src/metrics/classification/metrics.rs
@@ -2,7 +2,7 @@ use crate::metrics::*;
 
 pub struct LogLossMetric {}
 impl EvaluationMetric for LogLossMetric {
-    fn calculate_metric(y: &[f64], yhat: &[f64], sample_weight: &[f64], group: &[u64], _alpha: Option<f32>) -> f64 {
+    fn calculate_metric(y: &[f64], yhat: &[f64], sample_weight: &[f64], _group: &[u64], _alpha: Option<f32>) -> f64 {
         log_loss(y, yhat, sample_weight)
     }
     fn maximize() -> bool {
@@ -12,7 +12,7 @@ impl EvaluationMetric for LogLossMetric {
 
 pub struct AUCMetric {}
 impl EvaluationMetric for AUCMetric {
-    fn calculate_metric(y: &[f64], yhat: &[f64], sample_weight: &[f64], group: &[u64], _alpha: Option<f32>) -> f64 {
+    fn calculate_metric(y: &[f64], yhat: &[f64], sample_weight: &[f64], _group: &[u64], _alpha: Option<f32>) -> f64 {
         roc_auc_score(y, yhat, sample_weight)
     }
     fn maximize() -> bool {

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -4,7 +4,7 @@ pub mod regression;
 
 use crate::data::FloatData;
 use crate::errors::PerpetualError;
-use crate::metrics::ranking::GainScheme;
+pub use crate::metrics::ranking::GainScheme;
 use crate::utils::items_to_strings;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;

--- a/src/metrics/ranking/metrics.rs
+++ b/src/metrics/ranking/metrics.rs
@@ -1,0 +1,21 @@
+use crate::metrics::*;
+
+pub struct NDCGMetric {
+    #[allow(dead_code)]
+    k: Option<u64>,
+}
+
+impl NDCGMetric {
+    pub fn new(k: Option<u64>) -> Self {
+        Self { k }
+    }
+}
+
+impl EvaluationMetric for NDCGMetric {
+    fn calculate_metric(_y: &[f64], _yhat: &[f64], _sample_weight: &[f64], _alpha: Option<f32>) -> f64 {
+        todo!()
+    }
+    fn maximize() -> bool {
+        true
+    }
+}

--- a/src/metrics/ranking/metrics.rs
+++ b/src/metrics/ranking/metrics.rs
@@ -1,21 +1,152 @@
 use crate::metrics::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+pub enum GainScheme {
+    Jarvelin,
+    Burges,
+}
 
 pub struct NDCGMetric {
-    #[allow(dead_code)]
     k: Option<u64>,
+    gain: GainScheme,
 }
 
 impl NDCGMetric {
-    pub fn new(k: Option<u64>) -> Self {
-        Self { k }
+    pub fn new(k: Option<u64>, gain: GainScheme) -> Self {
+        Self { k, gain }
     }
 }
 
 impl EvaluationMetric for NDCGMetric {
-    fn calculate_metric(_y: &[f64], _yhat: &[f64], _sample_weight: &[f64], _alpha: Option<f32>) -> f64 {
-        todo!()
+    fn calculate_metric(y: &[f64], yhat: &[f64], sample_weight: &[f64], group: &[u64], _alpha: Option<f32>) -> f64 {
+        // TODO: find way to handle k and gain scheme, either include in trait like alpha or add to struct and box
+        // the metric functions
+        ndcg_at_k_metric(y, yhat, sample_weight, group, None, &GainScheme::Burges)
     }
     fn maximize() -> bool {
         true
+    }
+}
+
+#[inline]
+fn compute_discount(rank: usize) -> f64 {
+    1.0 / ((rank + 2) as f64).log2()
+}
+
+#[inline]
+fn compute_gain(relevance: f64, scheme: &GainScheme) -> f64 {
+    match scheme {
+        GainScheme::Jarvelin => relevance,
+        GainScheme::Burges => 2_f64.powf(relevance) - 1.0,
+    }
+}
+
+fn compute_group_dcg(relevance_scores: &[f64], k: Option<u64>, weights: &[f64], scheme: &GainScheme) -> f64 {
+    let limit = k
+        .map(|k| k as usize)
+        .unwrap_or(relevance_scores.len())
+        .min(relevance_scores.len());
+
+    relevance_scores
+        .iter()
+        .zip(weights)
+        .take(limit)
+        .enumerate()
+        .map(|(rank, (&relevance, &weight))| {
+            let gain = compute_gain(relevance, scheme) * weight;
+            let discount = compute_discount(rank);
+            gain * discount
+        })
+        .sum()
+}
+
+fn compute_group_ndcg(
+    y_group: &[f64],
+    yhat_group: &[f64],
+    weights_group: &[f64],
+    k: Option<u64>,
+    scheme: &GainScheme,
+) -> f64 {
+    if y_group.is_empty() {
+        return 0.0;
+    }
+
+    // Create (relevance, prediction, weight) tuples with original indices
+    let mut items: Vec<(f64, f64, f64, usize)> = y_group
+        .iter()
+        .zip(yhat_group)
+        .zip(weights_group)
+        .enumerate()
+        .map(|(idx, ((&y, &yhat), &weight))| (y, yhat, weight, idx))
+        .collect();
+
+    // Sort by predictions (descending) to get predicted ranking
+    items.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+    // Extract relevance scores and weights in predicted order
+    let predicted_relevance: Vec<f64> = items.iter().map(|(y, _, _, _)| *y).collect();
+    let predicted_weights: Vec<f64> = items.iter().map(|(_, _, weight, _)| *weight).collect();
+
+    // Compute DCG for predicted ranking
+    let dcg = compute_group_dcg(&predicted_relevance, k, &predicted_weights, scheme);
+
+    // Compute IDCG (Ideal DCG) by sorting by true relevance
+    items.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+    let ideal_relevance: Vec<f64> = items.iter().map(|(y, _, _, _)| *y).collect();
+    let ideal_weights: Vec<f64> = items.iter().map(|(_, _, weight, _)| *weight).collect();
+
+    let idcg = compute_group_dcg(&ideal_relevance, k, &ideal_weights, scheme);
+
+    // Return NDCG
+    if idcg > 0.0 {
+        dcg / idcg
+    } else {
+        0.0
+    }
+}
+
+pub fn ndcg_at_k_metric(
+    y: &[f64],
+    yhat: &[f64],
+    sample_weight: &[f64],
+    group: &[u64],
+    k: Option<u64>,
+    scheme: &GainScheme,
+) -> f64 {
+    if y.is_empty() {
+        return 0.0;
+    }
+
+    let mut start = 0;
+    let mut total_ndcg = 0.0;
+    let mut total_weight = 0.0;
+
+    for &group_size in group {
+        let end = start + group_size as usize;
+
+        if end > y.len() {
+            break;
+        }
+
+        let y_group = &y[start..end];
+        let yhat_group = &yhat[start..end];
+        let weights_group = &sample_weight[start..end];
+
+        let group_ndcg = compute_group_ndcg(y_group, yhat_group, weights_group, k, scheme);
+
+        // Weight each group's NDCG by the sum of its sample weights
+        // TODO: is the the desired behaviour?
+        let group_weight: f64 = weights_group.iter().sum();
+        total_ndcg += group_ndcg * group_weight;
+        total_weight += group_weight;
+
+        start = end;
+    }
+
+    if total_weight > 0.0 {
+        total_ndcg / total_weight
+    } else {
+        0.0
     }
 }

--- a/src/metrics/ranking/metrics.rs
+++ b/src/metrics/ranking/metrics.rs
@@ -1,7 +1,7 @@
 use crate::metrics::*;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, Eq, PartialEq)]
 pub enum GainScheme {
     Jarvelin,
     Burges,
@@ -147,6 +147,7 @@ pub fn ndcg_at_k_metric(
     if total_weight > 0.0 {
         total_ndcg / total_weight
     } else {
+        // TODO: I dont know what would be logical/optimal here
         0.0
     }
 }

--- a/src/metrics/ranking/mod.rs
+++ b/src/metrics/ranking/mod.rs
@@ -1,0 +1,2 @@
+pub mod metrics;
+pub use metrics::*;

--- a/src/metrics/regression/metrics.rs
+++ b/src/metrics/regression/metrics.rs
@@ -2,7 +2,7 @@ use crate::metrics::*;
 
 pub struct QuantileLossMetric {}
 impl EvaluationMetric for QuantileLossMetric {
-    fn calculate_metric(y: &[f64], yhat: &[f64], sample_weight: &[f64], alpha: Option<f32>) -> f64 {
+    fn calculate_metric(y: &[f64], yhat: &[f64], sample_weight: &[f64], _group: &[u64], alpha: Option<f32>) -> f64 {
         quantile_loss(y, yhat, sample_weight, alpha)
     }
     fn maximize() -> bool {
@@ -12,7 +12,7 @@ impl EvaluationMetric for QuantileLossMetric {
 
 pub struct RootMeanSquaredLogErrorMetric {}
 impl EvaluationMetric for RootMeanSquaredLogErrorMetric {
-    fn calculate_metric(y: &[f64], yhat: &[f64], sample_weight: &[f64], _alpha: Option<f32>) -> f64 {
+    fn calculate_metric(y: &[f64], yhat: &[f64], sample_weight: &[f64], _group: &[u64], _alpha: Option<f32>) -> f64 {
         root_mean_squared_log_error(y, yhat, sample_weight)
     }
     fn maximize() -> bool {
@@ -22,7 +22,7 @@ impl EvaluationMetric for RootMeanSquaredLogErrorMetric {
 
 pub struct RootMeanSquaredErrorMetric {}
 impl EvaluationMetric for RootMeanSquaredErrorMetric {
-    fn calculate_metric(y: &[f64], yhat: &[f64], sample_weight: &[f64], _alpha: Option<f32>) -> f64 {
+    fn calculate_metric(y: &[f64], yhat: &[f64], sample_weight: &[f64], _group: &[u64], _alpha: Option<f32>) -> f64 {
         root_mean_squared_error(y, yhat, sample_weight)
     }
     fn maximize() -> bool {

--- a/src/node.rs
+++ b/src/node.rs
@@ -125,6 +125,7 @@ pub enum NodeType {
 }
 
 impl SplittableNode {
+    #[allow(clippy::too_many_arguments)]
     pub fn from_node_info(
         num: usize,
         depth: usize,

--- a/src/objective_functions/adaptive_huber_loss.rs
+++ b/src/objective_functions/adaptive_huber_loss.rs
@@ -12,7 +12,7 @@ pub struct AdaptiveHuberLoss {
 }
 impl ObjectiveFunction for AdaptiveHuberLoss {
     #[inline]
-    fn loss(&self, y: &[f64], yhat: &[f64], sample_weight: Option<&[f64]>) -> Vec<f32> {
+    fn loss(&self, y: &[f64], yhat: &[f64], sample_weight: Option<&[f64]>, _group: Option<&[u64]>) -> Vec<f32> {
         // default alpha: 0.5
         // if not passed explicitly
         let alpha = self.quantile.unwrap_or(0.5);
@@ -62,7 +62,13 @@ impl ObjectiveFunction for AdaptiveHuberLoss {
     }
 
     #[inline]
-    fn gradient(&self, y: &[f64], yhat: &[f64], sample_weight: Option<&[f64]>) -> (Vec<f32>, Option<Vec<f32>>) {
+    fn gradient(
+        &self,
+        y: &[f64],
+        yhat: &[f64],
+        sample_weight: Option<&[f64]>,
+        _group: Option<&[u64]>,
+    ) -> (Vec<f32>, Option<Vec<f32>>) {
         // default alpha: 0.5
         // if not passed explicitly
         let alpha = self.quantile.unwrap_or(0.5);
@@ -118,7 +124,7 @@ impl ObjectiveFunction for AdaptiveHuberLoss {
         }
     }
 
-    fn initial_value(&self, y: &[f64], sample_weight: Option<&[f64]>) -> f64 {
+    fn initial_value(&self, y: &[f64], sample_weight: Option<&[f64]>, _group: Option<&[u64]>) -> f64 {
         let mut idxs = (0..y.len()).collect::<Vec<_>>();
         idxs.sort_by(|&i, &j| y[i].partial_cmp(&y[j]).unwrap());
 

--- a/src/objective_functions/huber_loss.rs
+++ b/src/objective_functions/huber_loss.rs
@@ -11,7 +11,7 @@ pub struct HuberLoss {
 }
 impl ObjectiveFunction for HuberLoss {
     #[inline]
-    fn loss(&self, y: &[f64], yhat: &[f64], sample_weight: Option<&[f64]>) -> Vec<f32> {
+    fn loss(&self, y: &[f64], yhat: &[f64], sample_weight: Option<&[f64]>, _group: Option<&[u64]>) -> Vec<f32> {
         let delta = self.delta.unwrap_or(1.0);
         match sample_weight {
             Some(weights) => y
@@ -47,7 +47,13 @@ impl ObjectiveFunction for HuberLoss {
     }
 
     #[inline]
-    fn gradient(&self, y: &[f64], yhat: &[f64], sample_weight: Option<&[f64]>) -> (Vec<f32>, Option<Vec<f32>>) {
+    fn gradient(
+        &self,
+        y: &[f64],
+        yhat: &[f64],
+        sample_weight: Option<&[f64]>,
+        _group: Option<&[u64]>,
+    ) -> (Vec<f32>, Option<Vec<f32>>) {
         let delta = self.delta.unwrap_or(1.0);
 
         match sample_weight {
@@ -90,7 +96,7 @@ impl ObjectiveFunction for HuberLoss {
     }
 
     #[inline]
-    fn initial_value(&self, y: &[f64], sample_weight: Option<&[f64]>) -> f64 {
+    fn initial_value(&self, y: &[f64], sample_weight: Option<&[f64]>, _group: Option<&[u64]>) -> f64 {
         let mut idxs = (0..y.len()).collect::<Vec<_>>();
         idxs.sort_by(|&i, &j| y[i].partial_cmp(&y[j]).unwrap());
 

--- a/src/objective_functions/listnet_loss.rs
+++ b/src/objective_functions/listnet_loss.rs
@@ -19,7 +19,7 @@ fn compute_softmax_inplace(input: &[f64], output: &mut [f32]) {
     let max_val = input.iter().fold(f64::NEG_INFINITY, |a, &b| a.max(b));
     let mut sum = 0.0f32;
 
-    // First pass: compute exp and suxp trick?
+    // First pass: compute exp and sum
     for (i, &val) in input.iter().enumerate() {
         let exp_val = ((val - max_val) as f32).exp();
         output[i] = exp_val;

--- a/src/objective_functions/listnet_loss.rs
+++ b/src/objective_functions/listnet_loss.rs
@@ -197,8 +197,7 @@ impl ObjectiveFunction for ListNetLoss {
 
     #[inline]
     fn initial_value(&self, _y: &[f64], _sample_weight: Option<&[f64]>, _group: Option<&[u64]>) -> f64 {
-        // TODO: I dont know what would be logical/optimal here
-        f64::INFINITY
+        0.0
     }
 
     fn default_metric(&self) -> Metric {

--- a/src/objective_functions/listnet_loss.rs
+++ b/src/objective_functions/listnet_loss.rs
@@ -1,0 +1,36 @@
+//! ListNet Loss function
+//!
+//!
+use super::ObjectiveFunction;
+use crate::metrics::Metric;
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Debug, Deserialize, Serialize, Clone)]
+pub struct ListNetLoss {}
+
+impl ObjectiveFunction for ListNetLoss {
+    #[inline]
+    fn loss(&self, _y: &[f64], _yhat: &[f64], _sample_weight: Option<&[f64]>, _group: Option<&[u64]>) -> Vec<f32> {
+        todo!()
+    }
+
+    #[inline]
+    fn gradient(
+        &self,
+        _y: &[f64],
+        _yhat: &[f64],
+        _sample_weight: Option<&[f64]>,
+        _group: Option<&[u64]>,
+    ) -> (Vec<f32>, Option<Vec<f32>>) {
+        todo!()
+    }
+
+    #[inline]
+    fn initial_value(&self, _y: &[f64], _sample_weight: Option<&[f64]>, _group: Option<&[u64]>) -> f64 {
+        todo!()
+    }
+
+    fn default_metric(&self) -> Metric {
+        Metric::NDCG { k: None }
+    }
+}

--- a/src/objective_functions/listnet_loss.rs
+++ b/src/objective_functions/listnet_loss.rs
@@ -2,35 +2,193 @@
 //!
 //!
 use super::ObjectiveFunction;
+use crate::metrics::ranking::GainScheme;
 use crate::metrics::Metric;
 use serde::{Deserialize, Serialize};
 
 #[derive(Default, Debug, Deserialize, Serialize, Clone)]
 pub struct ListNetLoss {}
 
+#[inline]
+fn compute_softmax_inplace(input: &[f64], output: &mut [f32]) {
+    debug_assert_eq!(input.len(), output.len());
+
+    let max_val = input.iter().fold(f64::NEG_INFINITY, |a, &b| a.max(b));
+    let mut sum = 0.0f32;
+
+    // First pass: compute exp and sum
+    // TODO: for stability do log sum exp trick?
+    for (i, &val) in input.iter().enumerate() {
+        let exp_val = ((val - max_val) as f32).exp();
+        output[i] = exp_val;
+        sum += exp_val;
+    }
+
+    // Second pass: normalize
+    if sum > 0.0 {
+        let inv_sum = 1.0 / sum;
+        for val in output.iter_mut() {
+            *val *= inv_sum;
+        }
+    }
+}
+
+#[inline]
+fn compute_listnet_loss(softmax_y: &[f32], softmax_yhat: &[f32], weights: Option<&[f64]>) -> f32 {
+    match weights {
+        Some(w) => softmax_y
+            .iter()
+            .zip(softmax_yhat)
+            .zip(w)
+            .map(|((p_y, p_yhat), weight)| {
+                if *p_y > 0.0 {
+                    -p_y * p_yhat.ln() * (*weight as f32)
+                } else {
+                    0.0
+                }
+            })
+            .sum(),
+        None => softmax_y
+            .iter()
+            .zip(softmax_yhat)
+            .map(|(p_y, p_yhat)| if *p_y > 0.0 { -p_y * p_yhat.ln() } else { 0.0 })
+            .sum(),
+    }
+}
+
+#[inline]
+fn compute_group_gradients(softmax_y: &[f32], softmax_yhat: &[f32], weights: Option<&[f64]>, output: &mut [f32]) {
+    match weights {
+        Some(w) => {
+            for (i, ((p_yhat, p_y), weight)) in softmax_yhat.iter().zip(softmax_y).zip(w).enumerate() {
+                output[i] = (p_yhat - p_y) * (*weight as f32);
+            }
+        }
+        None => {
+            for (i, (p_yhat, p_y)) in softmax_yhat.iter().zip(softmax_y).enumerate() {
+                output[i] = p_yhat - p_y;
+            }
+        }
+    }
+}
+
+#[inline]
+fn compute_group_hessian(softmax_yhat: &[f32], weights: Option<&[f64]>, output: &mut [f32]) {
+    // For ListNet, the hessian is H_ii = p_i * (1 - p_i) * weight_i
+    match weights {
+        Some(w) => {
+            for (i, (p_yhat, weight)) in softmax_yhat.iter().zip(w).enumerate() {
+                output[i] = p_yhat * (1.0 - p_yhat) * (*weight as f32);
+            }
+        }
+        None => {
+            for (i, p_yhat) in softmax_yhat.iter().enumerate() {
+                output[i] = p_yhat * (1.0 - p_yhat);
+            }
+        }
+    }
+}
+
 impl ObjectiveFunction for ListNetLoss {
     #[inline]
-    fn loss(&self, _y: &[f64], _yhat: &[f64], _sample_weight: Option<&[f64]>, _group: Option<&[u64]>) -> Vec<f32> {
-        todo!()
+    fn loss(&self, y: &[f64], yhat: &[f64], sample_weight: Option<&[f64]>, group: Option<&[u64]>) -> Vec<f32> {
+        let mut losses = vec![0.0f32; y.len()];
+
+        if let Some(group_sizes) = group {
+            let mut start = 0;
+            for &group_size in group_sizes {
+                let end = start + group_size as usize;
+                let group_len = group_size as usize;
+
+                let y_group = &y[start..end];
+                let yhat_group = &yhat[start..end];
+                let weight_group = sample_weight.map(|w| &w[start..end]);
+
+                let mut softmax_y = vec![0.0f32; group_len];
+                let mut softmax_yhat = vec![0.0f32; group_len];
+
+                compute_softmax_inplace(y_group, &mut softmax_y);
+                compute_softmax_inplace(yhat_group, &mut softmax_yhat);
+
+                let group_loss = compute_listnet_loss(&softmax_y, &softmax_yhat, weight_group);
+
+                let per_sample_loss = group_loss / (group_size as f32);
+                losses[start..end].fill(per_sample_loss);
+                start = end;
+            }
+        } else {
+            let mut softmax_y = vec![0.0f32; y.len()];
+            let mut softmax_yhat = vec![0.0f32; y.len()];
+
+            compute_softmax_inplace(y, &mut softmax_y);
+            compute_softmax_inplace(yhat, &mut softmax_yhat);
+
+            let total_loss = compute_listnet_loss(&softmax_y, &softmax_yhat, sample_weight);
+
+            let per_sample_loss = total_loss / (y.len() as f32);
+            losses.fill(per_sample_loss);
+        }
+
+        losses
     }
 
     #[inline]
     fn gradient(
         &self,
-        _y: &[f64],
-        _yhat: &[f64],
-        _sample_weight: Option<&[f64]>,
-        _group: Option<&[u64]>,
+        y: &[f64],
+        yhat: &[f64],
+        sample_weight: Option<&[f64]>,
+        group: Option<&[u64]>,
     ) -> (Vec<f32>, Option<Vec<f32>>) {
-        todo!()
+        let mut gradients = vec![0.0f32; y.len()];
+        let mut hessians = vec![0.0f32; y.len()];
+
+        if let Some(group_sizes) = group {
+            let mut start = 0;
+            for &group_size in group_sizes {
+                let end = start + group_size as usize;
+                let group_len = group_size as usize;
+
+                let y_group = &y[start..end];
+                let yhat_group = &yhat[start..end];
+                let weight_group = sample_weight.map(|w| &w[start..end]);
+
+                let mut softmax_y = vec![0.0f32; group_len];
+                let mut softmax_yhat = vec![0.0f32; group_len];
+
+                compute_softmax_inplace(y_group, &mut softmax_y);
+                compute_softmax_inplace(yhat_group, &mut softmax_yhat);
+
+                compute_group_gradients(&softmax_y, &softmax_yhat, weight_group, &mut gradients[start..end]);
+
+                compute_group_hessian(&softmax_yhat, weight_group, &mut hessians[start..end]);
+
+                start = end;
+            }
+        } else {
+            let mut softmax_y = vec![0.0f32; y.len()];
+            let mut softmax_yhat = vec![0.0f32; y.len()];
+
+            compute_softmax_inplace(y, &mut softmax_y);
+            compute_softmax_inplace(yhat, &mut softmax_yhat);
+
+            compute_group_gradients(&softmax_y, &softmax_yhat, sample_weight, &mut gradients);
+
+            compute_group_hessian(&softmax_yhat, sample_weight, &mut hessians);
+        }
+
+        (gradients, Some(hessians))
     }
 
     #[inline]
     fn initial_value(&self, _y: &[f64], _sample_weight: Option<&[f64]>, _group: Option<&[u64]>) -> f64 {
-        todo!()
+        0.0
     }
 
     fn default_metric(&self) -> Metric {
-        Metric::NDCG { k: None }
+        Metric::NDCG {
+            k: None,
+            gain: GainScheme::Burges,
+        }
     }
 }

--- a/src/objective_functions/log_loss.rs
+++ b/src/objective_functions/log_loss.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 pub struct LogLoss {}
 impl ObjectiveFunction for LogLoss {
     #[inline]
-    fn loss(&self, y: &[f64], yhat: &[f64], sample_weight: Option<&[f64]>) -> Vec<f32> {
+    fn loss(&self, y: &[f64], yhat: &[f64], sample_weight: Option<&[f64]>, _group: Option<&[u64]>) -> Vec<f32> {
         match sample_weight {
             Some(sample_weight) => y
                 .iter()
@@ -32,7 +32,7 @@ impl ObjectiveFunction for LogLoss {
     }
 
     #[inline]
-    fn initial_value(&self, y: &[f64], sample_weight: Option<&[f64]>) -> f64 {
+    fn initial_value(&self, y: &[f64], sample_weight: Option<&[f64]>, _group: Option<&[u64]>) -> f64 {
         match sample_weight {
             Some(sample_weight) => {
                 let mut ytot: f64 = 0.;
@@ -52,7 +52,13 @@ impl ObjectiveFunction for LogLoss {
     }
 
     #[inline]
-    fn gradient(&self, y: &[f64], yhat: &[f64], sample_weight: Option<&[f64]>) -> (Vec<f32>, Option<Vec<f32>>) {
+    fn gradient(
+        &self,
+        y: &[f64],
+        yhat: &[f64],
+        sample_weight: Option<&[f64]>,
+        _group: Option<&[u64]>,
+    ) -> (Vec<f32>, Option<Vec<f32>>) {
         match sample_weight {
             Some(sample_weight) => {
                 let (g, h) = y

--- a/src/objective_functions/mod.rs
+++ b/src/objective_functions/mod.rs
@@ -8,6 +8,7 @@
 // import modules
 mod adaptive_huber_loss;
 mod huber_loss;
+mod listnet_loss;
 mod log_loss;
 mod quantile_loss;
 mod squared_loss;
@@ -15,6 +16,7 @@ mod squared_loss;
 // make loss functions public
 pub use adaptive_huber_loss::AdaptiveHuberLoss;
 pub use huber_loss::HuberLoss;
+pub use listnet_loss::ListNetLoss;
 pub use log_loss::LogLoss;
 pub use quantile_loss::QuantileLoss;
 pub use squared_loss::SquaredLoss;
@@ -26,9 +28,9 @@ use std::sync::Arc;
 
 // define types as smartpointers for thread safety
 pub type ObjectiveFn =
-    Arc<dyn Fn(&[f64], &[f64], Option<&[f64]>) -> (Vec<f32>, Option<Vec<f32>>) + Send + Sync + 'static>;
-pub type LossFn = Arc<dyn Fn(&[f64], &[f64], Option<&[f64]>) -> Vec<f32> + Send + Sync + 'static>;
-pub type InitialValueFn = Arc<dyn Fn(&[f64], Option<&[f64]>) -> f64 + Send + Sync + 'static>;
+    Arc<dyn Fn(&[f64], &[f64], Option<&[f64]>, Option<&[u64]>) -> (Vec<f32>, Option<Vec<f32>>) + Send + Sync + 'static>;
+pub type LossFn = Arc<dyn Fn(&[f64], &[f64], Option<&[f64]>, Option<&[u64]>) -> Vec<f32> + Send + Sync + 'static>;
+pub type InitialValueFn = Arc<dyn Fn(&[f64], Option<&[f64]>, Option<&[u64]>) -> f64 + Send + Sync + 'static>;
 
 // define traits for the objective
 // functions.
@@ -49,9 +51,15 @@ pub type InitialValueFn = Arc<dyn Fn(&[f64], Option<&[f64]>) -> f64 + Send + Syn
 ///
 ///
 pub trait ObjectiveFunction: Send + Sync {
-    fn loss(&self, y: &[f64], yhat: &[f64], sample_weight: Option<&[f64]>) -> Vec<f32>;
-    fn gradient(&self, y: &[f64], yhat: &[f64], sample_weight: Option<&[f64]>) -> (Vec<f32>, Option<Vec<f32>>);
-    fn initial_value(&self, y: &[f64], sample_weight: Option<&[f64]>) -> f64;
+    fn loss(&self, y: &[f64], yhat: &[f64], sample_weight: Option<&[f64]>, group: Option<&[u64]>) -> Vec<f32>;
+    fn gradient(
+        &self,
+        y: &[f64],
+        yhat: &[f64],
+        sample_weight: Option<&[f64]>,
+        group: Option<&[u64]>,
+    ) -> (Vec<f32>, Option<Vec<f32>>);
+    fn initial_value(&self, y: &[f64], sample_weight: Option<&[f64]>, group: Option<&[u64]>) -> f64;
     fn default_metric(&self) -> Metric;
 }
 
@@ -64,21 +72,21 @@ pub fn loss_callables<T>(instance: Arc<T>) -> LossFn
 where
     T: ObjectiveFunction + ?Sized + 'static,
 {
-    Arc::new(move |y, yhat, w| instance.clone().loss(y, yhat, w))
+    Arc::new(move |y, yhat, w, g| instance.clone().loss(y, yhat, w, g))
 }
 
 pub fn gradient_callables<T>(instance: Arc<T>) -> ObjectiveFn
 where
     T: ObjectiveFunction + ?Sized + 'static,
 {
-    Arc::new(move |y, yhat, w| instance.clone().gradient(y, yhat, w))
+    Arc::new(move |y, yhat, w, g| instance.clone().gradient(y, yhat, w, g))
 }
 
 pub fn initial_value_callables<T>(instance: Arc<T>) -> InitialValueFn
 where
     T: ObjectiveFunction + ?Sized + 'static,
 {
-    Arc::new(move |y, w| instance.clone().initial_value(y, w))
+    Arc::new(move |y, w, g| instance.clone().initial_value(y, w, g))
 }
 
 // define Objective enum
@@ -109,6 +117,7 @@ pub enum Objective {
     AdaptiveHuberLoss {
         quantile: Option<f64>,
     },
+    ListNetLoss,
 
     /// Custom objective function
     ///
@@ -136,6 +145,7 @@ impl Objective {
             Objective::QuantileLoss { quantile } => Arc::new(QuantileLoss { quantile: *quantile }),
             Objective::HuberLoss { delta } => Arc::new(HuberLoss { delta: *delta }),
             Objective::AdaptiveHuberLoss { quantile } => Arc::new(AdaptiveHuberLoss { quantile: *quantile }),
+            Objective::ListNetLoss => Arc::new(ListNetLoss::default()),
             Objective::Custom(arc) => arc.clone(),
         }
     }
@@ -149,16 +159,22 @@ impl<T> ObjectiveFunction for Arc<T>
 where
     T: ObjectiveFunction + Send + Sync + ?Sized + 'static,
 {
-    fn loss(&self, y: &[f64], yhat: &[f64], sample_weight: Option<&[f64]>) -> Vec<f32> {
-        (**self).loss(y, yhat, sample_weight)
+    fn loss(&self, y: &[f64], yhat: &[f64], sample_weight: Option<&[f64]>, group: Option<&[u64]>) -> Vec<f32> {
+        (**self).loss(y, yhat, sample_weight, group)
     }
 
-    fn gradient(&self, y: &[f64], yhat: &[f64], sample_weight: Option<&[f64]>) -> (Vec<f32>, Option<Vec<f32>>) {
-        (**self).gradient(y, yhat, sample_weight)
+    fn gradient(
+        &self,
+        y: &[f64],
+        yhat: &[f64],
+        sample_weight: Option<&[f64]>,
+        group: Option<&[u64]>,
+    ) -> (Vec<f32>, Option<Vec<f32>>) {
+        (**self).gradient(y, yhat, sample_weight, group)
     }
 
-    fn initial_value(&self, y: &[f64], sample_weight: Option<&[f64]>) -> f64 {
-        (**self).initial_value(y, sample_weight)
+    fn initial_value(&self, y: &[f64], sample_weight: Option<&[f64]>, group: Option<&[u64]>) -> f64 {
+        (**self).initial_value(y, sample_weight, group)
     }
 
     fn default_metric(&self) -> Metric {
@@ -206,11 +222,11 @@ mod test {
     // helper function for the
     // tests
     fn sum_loss(obj: &Arc<dyn crate::objective_functions::ObjectiveFunction>, yhat: &[f64]) -> f32 {
-        obj.loss(Y, yhat, None).iter().copied().sum()
+        obj.loss(Y, yhat, None, None).iter().copied().sum()
     }
 
     fn sum_grad(obj: &Arc<dyn crate::objective_functions::ObjectiveFunction>, yhat: &[f64]) -> f32 {
-        let (g, _) = obj.gradient(Y, yhat, None);
+        let (g, _) = obj.gradient(Y, yhat, None, None);
         g.iter().copied().sum()
     }
 
@@ -230,41 +246,54 @@ mod test {
     #[test]
     fn test_logloss_init() {
         let objective_function = Objective::LogLoss.as_function();
-        assert_eq!(objective_function.initial_value(Y, None), 0.0);
+        assert_eq!(objective_function.initial_value(Y, None, None), 0.0);
 
         let all_ones = vec![1.0; 6];
         assert_eq!(
-            Objective::LogLoss.as_function().initial_value(&all_ones, None),
+            Objective::LogLoss.as_function().initial_value(&all_ones, None, None),
             f64::INFINITY
         );
 
         let all_zeros = vec![0.0; 6];
         assert_eq!(
-            Objective::LogLoss.as_function().initial_value(&all_zeros, None),
+            Objective::LogLoss.as_function().initial_value(&all_zeros, None, None),
             f64::NEG_INFINITY
         );
 
         let mixed = &[0.0, 0.0, 0.0, 0.0, 1.0, 1.0];
         let expected = f64::ln(2.0 / 4.0);
-        assert_eq!(Objective::LogLoss.as_function().initial_value(mixed, None), expected);
+        assert_eq!(
+            Objective::LogLoss.as_function().initial_value(mixed, None, None),
+            expected
+        );
     }
 
     #[test]
     fn test_mse_init() {
         let objective_function = Objective::SquaredLoss.as_function();
-        assert_eq!(objective_function.initial_value(Y, None), 0.5);
+        assert_eq!(objective_function.initial_value(Y, None, None), 0.5);
 
         let all_ones = vec![1.0; 6];
-        assert_eq!(Objective::SquaredLoss.as_function().initial_value(&all_ones, None), 1.0);
+        assert_eq!(
+            Objective::SquaredLoss
+                .as_function()
+                .initial_value(&all_ones, None, None),
+            1.0
+        );
 
         let all_minus = vec![-1.0; 6];
         assert_eq!(
-            Objective::SquaredLoss.as_function().initial_value(&all_minus, None),
+            Objective::SquaredLoss
+                .as_function()
+                .initial_value(&all_minus, None, None),
             -1.0
         );
 
         let mixed = &[-1.0, -1.0, -1.0, 1.0, 1.0, 1.0];
-        assert_eq!(Objective::SquaredLoss.as_function().initial_value(mixed, None), 0.0);
+        assert_eq!(
+            Objective::SquaredLoss.as_function().initial_value(mixed, None, None),
+            0.0
+        );
     }
 
     #[test]
@@ -273,10 +302,10 @@ mod test {
         let y_vals = &[1.0, 2.0, 9.0, 3.2, 4.0];
 
         let objective_function_low = Objective::QuantileLoss { quantile: Some(0.1) }.as_function();
-        assert_eq!(objective_function_low.initial_value(y_vals, Some(weights)), 2.0);
+        assert_eq!(objective_function_low.initial_value(y_vals, Some(weights), None), 2.0);
 
         let objective_function_high = Objective::QuantileLoss { quantile: Some(0.9) }.as_function();
-        assert_eq!(objective_function_high.initial_value(y_vals, Some(weights)), 9.0);
+        assert_eq!(objective_function_high.initial_value(y_vals, Some(weights), None), 9.0);
     }
 
     #[test]
@@ -292,4 +321,6 @@ mod test {
         assert!(sum_loss(&objective_function, YHAT1) > sum_loss(&objective_function, YHAT2));
         assert!(sum_grad(&objective_function, YHAT1) < sum_grad(&objective_function, YHAT2));
     }
+
+    // TODO: add test for ranking loss
 }

--- a/src/objective_functions/mod.rs
+++ b/src/objective_functions/mod.rs
@@ -322,5 +322,37 @@ mod test {
         assert!(sum_grad(&objective_function, YHAT1) < sum_grad(&objective_function, YHAT2));
     }
 
-    // TODO: add test for ranking loss
+    static Y_RANK: &[f64] = &[1.0, 2.0, 3.0, 1.0, 2.0, 3.0];
+    static YHAT1_RANK: &[f64] = &[1.0, 2.0, 3.0, 1.0, 2.0, 3.0];
+    static YHAT2_RANK: &[f64] = &[3.0, 2.0, 1.0, 3.0, 2.0, 1.0];
+    static YHAT3_RANK: &[f64] = &[4.0, 5.0, 6.0, 4.0, 5.0, 6.0]; // NOTE: should be the
+                                                                 // same as YHAT1_RANK
+    static GROUP: &[u64] = &[3, 3];
+
+    fn sum_loss_rank(obj: &Arc<dyn crate::objective_functions::ObjectiveFunction>, yhat: &[f64]) -> f32 {
+        obj.loss(Y_RANK, yhat, None, Some(GROUP)).iter().copied().sum()
+    }
+
+    fn sum_grad_rank(obj: &Arc<dyn crate::objective_functions::ObjectiveFunction>, yhat: &[f64]) -> f32 {
+        let (g, _) = obj.gradient(Y_RANK, yhat, None, Some(GROUP));
+        g.iter().map(|x| x.abs()).sum()
+    }
+
+    #[test]
+    fn test_listnet_loss_and_grad() {
+        let objective_function = Objective::ListNetLoss.as_function();
+        let good_loss_sum = sum_loss_rank(&objective_function, YHAT1_RANK);
+        let bad_loss_sum = sum_loss_rank(&objective_function, YHAT2_RANK);
+        let also_good_loss_sum = sum_loss_rank(&objective_function, YHAT3_RANK);
+
+        let good_grad_sum = sum_grad_rank(&objective_function, YHAT1_RANK);
+        let bad_grad_sum = sum_grad_rank(&objective_function, YHAT2_RANK);
+        let also_good_grad_sum = sum_grad_rank(&objective_function, YHAT3_RANK);
+
+        assert!(good_loss_sum < bad_loss_sum);
+        assert!(good_grad_sum < bad_grad_sum);
+
+        assert!(good_loss_sum == also_good_loss_sum);
+        assert!(good_grad_sum == also_good_grad_sum);
+    }
 }

--- a/src/objective_functions/quantile_loss.rs
+++ b/src/objective_functions/quantile_loss.rs
@@ -10,7 +10,7 @@ pub struct QuantileLoss {
 }
 impl ObjectiveFunction for QuantileLoss {
     #[inline]
-    fn loss(&self, y: &[f64], yhat: &[f64], sample_weight: Option<&[f64]>) -> Vec<f32> {
+    fn loss(&self, y: &[f64], yhat: &[f64], sample_weight: Option<&[f64]>, _group: Option<&[u64]>) -> Vec<f32> {
         match sample_weight {
             Some(sample_weight) => y
                 .iter()
@@ -37,7 +37,13 @@ impl ObjectiveFunction for QuantileLoss {
     }
 
     #[inline]
-    fn gradient(&self, y: &[f64], yhat: &[f64], sample_weight: Option<&[f64]>) -> (Vec<f32>, Option<Vec<f32>>) {
+    fn gradient(
+        &self,
+        y: &[f64],
+        yhat: &[f64],
+        sample_weight: Option<&[f64]>,
+        _group: Option<&[u64]>,
+    ) -> (Vec<f32>, Option<Vec<f32>>) {
         match sample_weight {
             Some(sample_weight) => {
                 let (g, h) = y
@@ -78,7 +84,7 @@ impl ObjectiveFunction for QuantileLoss {
     }
 
     #[inline]
-    fn initial_value(&self, y: &[f64], sample_weight: Option<&[f64]>) -> f64 {
+    fn initial_value(&self, y: &[f64], sample_weight: Option<&[f64]>, _group: Option<&[u64]>) -> f64 {
         match sample_weight {
             Some(sample_weight) => {
                 let mut indices = (0..y.len()).collect::<Vec<_>>();

--- a/src/objective_functions/squared_loss.rs
+++ b/src/objective_functions/squared_loss.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 pub struct SquaredLoss {}
 impl ObjectiveFunction for SquaredLoss {
     #[inline]
-    fn loss(&self, y: &[f64], yhat: &[f64], sample_weight: Option<&[f64]>) -> Vec<f32> {
+    fn loss(&self, y: &[f64], yhat: &[f64], sample_weight: Option<&[f64]>, _group: Option<&[u64]>) -> Vec<f32> {
         match sample_weight {
             Some(sample_weight) => y
                 .iter()
@@ -32,7 +32,13 @@ impl ObjectiveFunction for SquaredLoss {
     }
 
     #[inline]
-    fn gradient(&self, y: &[f64], yhat: &[f64], sample_weight: Option<&[f64]>) -> (Vec<f32>, Option<Vec<f32>>) {
+    fn gradient(
+        &self,
+        y: &[f64],
+        yhat: &[f64],
+        sample_weight: Option<&[f64]>,
+        _group: Option<&[u64]>,
+    ) -> (Vec<f32>, Option<Vec<f32>>) {
         match sample_weight {
             Some(sample_weight) => {
                 let (g, h) = y
@@ -51,7 +57,7 @@ impl ObjectiveFunction for SquaredLoss {
     }
 
     #[inline]
-    fn initial_value(&self, y: &[f64], sample_weight: Option<&[f64]>) -> f64 {
+    fn initial_value(&self, y: &[f64], sample_weight: Option<&[f64]>, _group: Option<&[u64]>) -> f64 {
         match sample_weight {
             Some(sample_weight) => {
                 let mut ytot: f64 = 0.;

--- a/src/partial_dependence.rs
+++ b/src/partial_dependence.rs
@@ -97,8 +97,8 @@ mod tests {
         let file = fs::read_to_string("resources/performance.csv").expect("Something went wrong reading the file");
         let y: Vec<f64> = file.lines().map(|x| x.parse::<f64>().unwrap()).collect();
         let yhat = vec![0.5; y.len()];
-        let (mut g, mut h) = objective_function.gradient(&y, &yhat, None);
-        let loss = objective_function.loss(&y, &yhat, None);
+        let (mut g, mut h) = objective_function.gradient(&y, &yhat, None, None);
+        let loss = objective_function.loss(&y, &yhat, None, None);
 
         let data = Matrix::new(&data_vec, 891, 5);
         let splitter = MissingImputerSplitter::new(0.3, true, ConstraintMap::new());
@@ -138,6 +138,7 @@ mod tests {
             &y,
             //loss_fn.clone(),
             &yhat,
+            None,
             None,
             false,
             &mut hist_tree,

--- a/src/splitter.rs
+++ b/src/splitter.rs
@@ -1844,7 +1844,7 @@ mod tests {
         let y: Vec<f64> = file.lines().map(|x| x.parse::<f64>().unwrap()).collect();
         let yhat = vec![0.5; y.len()];
 
-        let (grad, hess) = objective_function.gradient(&y, &yhat, None);
+        let (grad, hess) = objective_function.gradient(&y, &yhat, None, None);
 
         let splitter = MissingImputerSplitter::new(0.3, true, ConstraintMap::new());
         let gradient_sum = grad.iter().sum();
@@ -1998,7 +1998,7 @@ mod tests {
 
         let y_test_avg = y_test.iter().sum::<f64>() / y_test.len() as f64;
         let yhat = vec![y_test_avg; y_test.len()];
-        let (grad, hess) = objective_function.gradient(&y_test, &yhat, None);
+        let (grad, hess) = objective_function.gradient(&y_test, &yhat, None, None);
 
         let splitter = MissingImputerSplitter::new(0.3, false, ConstraintMap::new());
 
@@ -2082,7 +2082,7 @@ mod tests {
 
         let y_avg = y.iter().sum::<f64>() / y.len() as f64;
         let yhat = vec![y_avg; y.len()];
-        let (grad, hess) = objective_function.gradient(&y, &yhat, None);
+        let (grad, hess) = objective_function.gradient(&y, &yhat, None, None);
 
         let splitter = MissingImputerSplitter::new(eta, false, ConstraintMap::new());
 
@@ -2174,6 +2174,8 @@ mod tests {
         Ok(())
     }
 
+    // TODO: add test_ranking
+
     #[test]
     fn test_gbm_categorical_sensory() -> Result<(), Box<dyn Error>> {
         // instantiate objective function
@@ -2194,7 +2196,7 @@ mod tests {
 
         let y_avg = y.iter().sum::<f64>() / y.len() as f64;
         let yhat = vec![y_avg; y.len()];
-        let (grad, hess) = objective_function.gradient(&y, &yhat, None);
+        let (grad, hess) = objective_function.gradient(&y, &yhat, None, None);
 
         let splitter = MissingImputerSplitter::new(eta, false, ConstraintMap::new());
 

--- a/src/tree/tree.rs
+++ b/src/tree/tree.rs
@@ -754,4 +754,6 @@ mod tests {
 
         Ok(())
     }
+
+    // TODO: add test_tree_ranking
 }

--- a/src/tree/tree.rs
+++ b/src/tree/tree.rs
@@ -164,10 +164,12 @@ impl Tree {
                                 None => None,
                             };
                             // TODO: is the behaviour we want here?
+                            // Currently the loss will always give back f32::INFINITY for a group
+                            // of 1 member
                             let gr: Vec<u64>;
                             let g = match group {
                                 Some(group) => {
-                                    gr = vec![group[_i]];
+                                    gr = vec![1];
                                     Some(&gr[..])
                                 }
                                 None => None,


### PR DESCRIPTION
This PR aims to provide an MVP to implement #41

The main changes are:
- Changed the `ObjectiveFunction` trait to take an extra optional `group` parameter which indicates the lengths of the groups in a ranking task. (LightGBM has a similar parameter, an alternative would be to take a slice of group ids instead). This required adding the parameter in a lot of files, hence the high file count for this PR.
- Implemented the [ListNet](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/[tr-2007-40.pdf](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/tr-2007-40.pdf)) ranking loss function,  with a test on the Goodreads Choice Awards OpenML dataset. I also updated `scripts/make_resources.py`  to  create a csv with the Goodreads dataset. In a unit test in `univariate_booster.rs` I have compared this to random guesses for the ranks.
- Added the NDCG@k ranking metric in Rust, including string parsing logic. 

I also added some TODOs for questions I did not have an answer for:
- ~~For now I have semi-hardcoded the NDCG@k to use k=None and linear gain weighting scheme, since the current setup does not support metrics having parameters directly. These parameters could be included in the `EvaluationMetric` trait like the `alpha` now or the functions could be Boxed/Arced~~
- ~~I am not sure whether the way I currently handle sample weighting in the NDCG makes sense~~
- ~~The ListNet loss is not defined for a single point prediction, so the logic in `tree.rs` to early stop(?) doesn't work~~
- I did not know what to use for initial value in the ListNet loss, so I opted for ~~infinity~~ 0.
- I think `tree.rs` should have a test for a ranking objective
- For the stopping based on the `target_loss_decrement` in `tree.rs`, a ranking objective like ListNet requires a different algorithm as  the loss is not defined for a single point prediction. I have currently implemented this by calculating the loss for all indices after updating y_hat for the node indices. This could be more efficient I think.

Please reach out if you have any questions!

EDIT: NDCG@k not relevant right now, updated python bindings, included `target_loss_decrement` logic in `tree.rs` for ranking objectives
Changed initial value of ListNer from infinity to zero